### PR TITLE
Export updates

### DIFF
--- a/editor/views.py
+++ b/editor/views.py
@@ -30,8 +30,9 @@ def home(request):
 def edit(request, pk):
     puzzle = get_object_or_404(Puzzle, pk=pk)
     if request.user == puzzle.owner:
-        context = {'puzzle': puzzle.data, 'pk': pk}
-        return render(request, 'editor/edit_puzzle.html', context=context)
+        js_boolean = 'true' if puzzle.completed else 'false'
+        context = {'puzzle': puzzle.data, 'pk': pk, 'completed': js_boolean }
+        return render(request, 'editor/puzzle.html', context=context)
     else:
         redirect('home')
 
@@ -40,8 +41,9 @@ def edit(request, pk):
 def review_complete(request, pk):
     puzzle = get_object_or_404(Puzzle, pk=pk)
     if request.user == puzzle.owner:
-        context = {'puzzle': puzzle.data, 'pk': pk}
-        return render(request, 'editor/completed_puzzle.html', context=context)
+        js_boolean = 'true' if puzzle.completed else 'false'
+        context = {'puzzle': puzzle.data, 'pk': pk, 'completed': js_boolean }
+        return render(request, 'editor/puzzle.html', context=context)
     else:
         redirect('home')
 

--- a/editor/views.py
+++ b/editor/views.py
@@ -83,12 +83,12 @@ def ny_times_pdf(request, pk):
     context = {'puzzle': puzzle, 'rows': rows,
                'across': across, 'down': down, 'address': form_data}
     html = render_to_string('editor/ny_times_pdf.html', context=context)
-    css = CSS('static/css/ny_times_pdf.css')
+    # css = CSS('static/css/ny_times_pdf.css')
     filename = "nyt_format.pdf"
 
     response = HttpResponse(content_type="application/pdf")
     response['Content-Disposition'] = f"attachment; filename={filename}"
-    HTML(string=html).write_pdf(response, stylesheets=[css])
+    HTML(string=html).write_pdf(response)
     return response
 
 
@@ -192,10 +192,10 @@ def test_pdf(pk):
     context = {'puzzle': puzzle, 'rows': rows,
                'across': across, 'down': down}
     html = render_to_string('editor/ny_times_pdf.html', context=context)
-    css = CSS('static/css/ny_times_pdf.css')
+    # css = CSS('static/css/ny_times_pdf.css')
     filename = "nyt_format.pdf"
 
     response = HttpResponse(content_type="application/pdf")
     response['Content-Disposition'] = f"attachment; filename={filename}"
-    HTML(string=html).write_pdf('./output.pdf', stylesheets=[css])
+    HTML(string=html).write_pdf('./output.pdf')
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -507,7 +507,7 @@ ________________________________________________ */
   flex-flow: row nowrap;
   align-items: flex-start;
   padding: 0 .5rem;
-  width: 100vw;
+  width: 100%;
 }
 
 .properties-container label {

--- a/templates/editor/puzzle.html
+++ b/templates/editor/puzzle.html
@@ -46,7 +46,7 @@
         </span>
         <div class="clue-input-container">
           <textarea id="clue-input" wrap="soft" maxlength="200" style="overflow:auto; resize:none;"
-            v-model.trim="currentClue"></textarea>
+            v-model.trim="currentClue" :disabled="completed"></textarea>
         </div>
 
         <div class="grid-container" tabindex="0">
@@ -89,12 +89,13 @@
       <div class="properties-container">
         <div class="title-container prop-container">
           <label for="title-inp">Title:</label>
-          <input v-model="title" type="text" id="title-inp" maxlength="64">
+          <input v-model="title" type="text" id="title-inp" maxlength="64" :disabled="completed">
         </div>
         <div class="description-container prop-container">
           <label for="description-inp">Description/Notes:</label>
-          <textarea v-model="description" id="description-inp" maxlength="1023"></textarea>
+          <textarea v-model="description" id="description-inp" maxlength="1023" :disabled="completed"></textarea>
         </div>
+        {% if not completed %}
         <div class="symmetry-container prop-container">
           These symmetry options determine how the black squares are automatically filled in symetrically.
           180&deg; rotational symmetry is the default and the pattern that most NY Times crosswords follow.
@@ -117,11 +118,14 @@
             <label for="none">None</label>
           </div>
         </div>
-
+        {% endif %}
         <div class="complete-container prop-container">
-          <button id="complete-btn" class="btn green" @click="completePuzzle">Mark as complete</button>
+          <button v-if="!completed" id="complete-btn" class="btn green" @click="completePuzzle">Mark as
+            complete</button>
         </div>
-
+        <div class="complete-container prop-container">
+          <button v-if="completed" id="complete-btn" class="btn green" @click="editPuzzle">Edit</button>
+        </div>
         <div class="delete-container prop-container">
           <label for="delete-btn">Delete this puzzle (this cannot be undone; export this puzzle's data if you need
             to keep a copy)</label>
@@ -220,6 +224,7 @@
   // get json string store it in a variable
   var puzzleData = JSON.parse(document.querySelector("#puzzle-data").textContent);
   const puzzlePK = {{ pk }}
+  const completed = {{ completed }}
 
   const BLACK = '.'
 
@@ -314,7 +319,8 @@
       down: 'down', // string needed for x-clue component prop
       activeCell: 0,
       inputArea: 0,
-      lastSaved: ''
+      lastSaved: '',
+      completed: completed
     },
 
     computed: {
@@ -507,6 +513,18 @@
             console.log(jsonResp.message)
             let dt = new Date()
             this.lastSaved = { date: dt.toLocaleDateString(), time: dt.toLocaleTimeString() }
+          })
+      },
+
+      editPuzzle() {
+        saveData = this.prepareSaveData(puzzleData)
+        return fetch(`/toggle-complete/?pk=${puzzlePK}`
+        )
+          .then(resp => resp.json())
+          .then(jsonData => {
+            if (jsonData.redirect === true) {
+              window.location.replace(`/edit/${puzzlePK}`)
+            }
           })
       },
 
@@ -756,19 +774,19 @@
     }
     console.log(formData)
     return editor.savePuzzle()
-    .then(r => {
-      return fetch(`/export/${puzzlePK}/`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(formData)
-      })
-        .then(resp => {
-          nytButton.textContent = "Download"
-          return resp.blob()
+      .then(r => {
+        return fetch(`/export/${puzzlePK}/`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(formData)
         })
-    })
+          .then(resp => {
+            nytButton.textContent = "Download"
+            return resp.blob()
+          })
+      })
       .then(blob => {
         let url = window.URL.createObjectURL(blob);
         let a = document.createElement('a');

--- a/templates/editor/puzzle.html
+++ b/templates/editor/puzzle.html
@@ -95,8 +95,8 @@
           <label for="description-inp">Description/Notes:</label>
           <textarea v-model="description" id="description-inp" maxlength="1023" :disabled="completed"></textarea>
         </div>
-        {% if not completed %}
-        <div class="symmetry-container prop-container">
+
+        <div v-if="!completed" class="symmetry-container prop-container">
           These symmetry options determine how the black squares are automatically filled in symetrically.
           180&deg; rotational symmetry is the default and the pattern that most NY Times crosswords follow.
           You can change this setting at will as you write your puzzle, and turn off automatic black square
@@ -118,14 +118,16 @@
             <label for="none">None</label>
           </div>
         </div>
-        {% endif %}
+
         <div class="complete-container prop-container">
-          <button v-if="!completed" id="complete-btn" class="btn green" @click="completePuzzle">Mark as
-            complete</button>
+          <button v-if="!completed" id="complete-btn" class="btn green" @click="completePuzzle">
+            Mark as complete
+          </button>
+          <button v-if="completed" id="complete-btn" class="btn green" @click="editPuzzle">
+            Edit
+          </button>
         </div>
-        <div class="complete-container prop-container">
-          <button v-if="completed" id="complete-btn" class="btn green" @click="editPuzzle">Edit</button>
-        </div>
+
         <div class="delete-container prop-container">
           <label for="delete-btn">Delete this puzzle (this cannot be undone; export this puzzle's data if you need
             to keep a copy)</label>

--- a/templates/editor/puzzle.html
+++ b/templates/editor/puzzle.html
@@ -168,7 +168,7 @@
       <div class="export-list-container">
         <div class="export-container">
           <a id="export-json" download="my_exported_puzzle.json" href="">
-            <button class="btn save-btn">Download as JSON</button>
+            <button id="json-btn" class="btn save-btn">Download as JSON</button>
           </a>
           (<a href="https://www.xwordinfo.com/">https://www.xwordinfo.com/</a> format)
         </div>
@@ -759,10 +759,14 @@
 
 
   // === Export Handlers ===
-  const jsn = editor.exportJSON()
-  const data = new File([jsn], 'my_exported_puzzle.json', { type: 'application/json' })
-  let url = window.URL.createObjectURL(data)
-  document.querySelector('#export-json').href = url
+  document.querySelector('#json-btn').addEventListener('click',(event)=>{
+    const jsn = editor.exportJSON()
+    const data = new File([jsn], 'my_exported_puzzle.json', { type: 'application/json' })
+    let url = window.URL.createObjectURL(data)
+    let anchor = document.querySelector('#export-json')
+    anchor.href = url
+    editor.savePuzzle()
+  })
 
 
   document.querySelector('#export-nytimes-pdf').addEventListener('submit', (event) => {


### PR DESCRIPTION
Now the edit puzzle and review complete puzzle views can use the same template, with all the same functionality as before.

Also, now the json download button works better (it saves the puzzle when it is clicked, just like the pdf export button does)